### PR TITLE
fix(android): classifier -> archiveClassifier for gradle upgrade

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -216,7 +216,7 @@ if (isNewArchitectureEnabled()) {
 
 afterEvaluate { project ->
   task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier = 'sources'
     from android.sourceSets.main.java.srcDirs
     include '**/*.java'
   }


### PR DESCRIPTION
The `classifier` property have been deprecated and replaced by `archiveClassifier` in gradle 7, and it should be removed in gradle 8.

I've tested it works on a RN 0.72 project.